### PR TITLE
Fix 'T peek(void)' function

### DIFF
--- a/src/utility/BlynkFifo2.h
+++ b/src/utility/BlynkFifo2.h
@@ -112,6 +112,7 @@ public:
 
     T peek(void)
     {
+        int r = _r;
         while (r == _w);
         return _b[r];
     }


### PR DESCRIPTION
The 'T peek(void)' function was missing the declaration for the 'r' variable, resulting in an error. 

Declared the 'r' variable in scope.

<!--
Thanks for contributing to Blynk library :-)

Please provide the following information for all PRs.
Replace [brackets] and placeholder text with your responses.
-->

### Description
This change fixes a bug in the peek function where the 'r' variable was not declared.

### Issues Resolved
None on Github that I found, but I thought I'd fix the problem while reporting it.
